### PR TITLE
fix: patch update, fix package.json import

### DIFF
--- a/svelte-cloudinary/package.json
+++ b/svelte-cloudinary/package.json
@@ -7,7 +7,7 @@
 		"dev": "vite dev",
 		"build": "vite build && npm run package",
 		"preview": "vite preview",
-		"package": "svelte-kit sync && svelte-package && publint",
+		"package": "svelte-kit sync && svelte-package && node scripts/copy-package.js && publint",
 		"prepublishOnly": "npm run package",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
 		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",

--- a/svelte-cloudinary/scripts/copy-package.js
+++ b/svelte-cloudinary/scripts/copy-package.js
@@ -1,0 +1,13 @@
+import fs from 'fs';
+
+// read file into JSON
+const pkg = JSON.parse(fs.readFileSync('package.json', 'utf-8'));
+
+// adjust pkg json however you like ..
+
+// write it to your output directory
+fs.writeFileSync(
+  './dist/package.json', // path to your output directory may vary
+  JSON.stringify(pkg, null, 2)
+);
+console.log('package.json written to /dist')

--- a/svelte-cloudinary/src/lib/constants/analytics.ts
+++ b/svelte-cloudinary/src/lib/constants/analytics.ts
@@ -1,5 +1,5 @@
 import sveltePkg from 'svelte/package.json';
-import pkg from '../../../package.json'
+import pkg from '../../package.json'
 export const SVELTE_CLOUDINARY_ANALYTICS_ID = 'E';
 export const SVELTE_CLOUDINARY_VERSION = pkg.version;
 export const SVELTE_VERSION = sveltePkg.version;


### PR DESCRIPTION
# Description

<!-- Include a summary of the change made and also list the dependencies that are required if any -->
Fix the issue when importing package.json 

The problem happens because `svelte/package` doesn't copy the package.json file anymore, I added a script to be copy that when building.

## Issue Ticket Number

Fixes #<ISSUE_NUMBER>

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/svelte-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/svelte-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/svelte-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
