### PR TITLE
Remove direct Props spread from Image tag

### DIFF
--- a/svelte-cloudinary/src/lib/components/CldImage.svelte
+++ b/svelte-cloudinary/src/lib/components/CldImage.svelte
@@ -26,6 +26,7 @@
 			CLD_OPTIONS.push(prop);
 		});
 	});
+
 	const imageProps = {
 		alt,
 		src,
@@ -39,7 +40,9 @@
 		.forEach((key) => (imageProps[key] = $$props[key]));
 
 	// Construct Cloudinary-specific props by looking for values for any of the supported prop keys
+
 	const cldOptions = {};
+
 	CLD_OPTIONS.forEach((key) => {
 		if ($$props[key]) {
 			// @ts-expect-error cldOptions doesn't know the types of the keys
@@ -62,14 +65,9 @@
 			console.warn(`Failed to preserve transformations: ${(e as Error).message}`);
 		}
 	}
-	const url = getCldImageUrl({
-		...imageProps,
-		...cldOptions,
-	})
 </script>
 
 <Image
-	{...$$props}
 	{...imageProps}
 	cdn="cloudinary"
 	transformer={({ width, url, height}) => {


### PR DESCRIPTION
# Description

Removes `props` from being spread on `Image` component.

This shoudln't be necessary as the relevant props are applied via:

https://github.com/cloudinary-community/svelte-cloudinary/blob/main/svelte-cloudinary/src/lib/components/CldImage.svelte#L56

This is to avoid any non-native props to be added to the DOM

## Issue Ticket Number

Fixes #25 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/svelte-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/svelte-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/svelte-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
