### PR TITLE
Consistent Responsive Sizing 

### DIFF
--- a/svelte-cloudinary/src/lib/components/CldImage.svelte
+++ b/svelte-cloudinary/src/lib/components/CldImage.svelte
@@ -70,14 +70,25 @@
 <Image
 	{...imageProps}
 	cdn="cloudinary"
-	transformer={({ width, url, height}) => {
-		return getCldImageUrl({
+	transformer={({ width }) => {
+		const options = {
 			...imageProps,
 			...cldOptions,
-			width,
-			height,
-			// @ts-ignore
-			src: url
-		})}
-	}
+			// Without, get a "never" type error on options.width
+			width: imageProps.width
+		}
+
+		options.width = typeof options.width === 'string' ? parseInt(options.width) : options.width;
+		options.height = typeof options.height === 'string' ? parseInt(options.height) : options.height;
+
+		// The transformer options are used to create dynamic sizing when working with responsive images
+		// so these should override the default options collected from the props alone if
+		// the results are different.
+
+		if ( typeof width === 'number' && typeof options.width === 'number' && width !== options.width ) {
+			options.widthResize = width;
+		}
+
+		return getCldImageUrl(options);
+	}}
 />


### PR DESCRIPTION
# Description

Responsively resizes after transformations to avoid inconsistent transformations on image.

**Note: i'm seeing wonkiness in different render passes for what URL is actually used**

## Issue Ticket Number

Fixes #32 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/svelte-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [ ] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/svelte-cloudinary/issues) ticket for this PR
- [ ] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/svelte-cloudinary/pulls) for the same update/change?
- [ ] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
