### PR TITLE
[docs]: Fix code block dark mode

### DIFF
--- a/docs/src/app.html
+++ b/docs/src/app.html
@@ -14,11 +14,28 @@
 		<link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
 		<link rel="manifest" href="/site.webmanifest" />
 		<meta name="theme-color" content="#000000" />
-		<link rel="preconnect" href="https://fonts.googleapis.com">
-		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-		<link href="https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;600;700&family=Poppins:wght@400;500;600;700&display=swap" rel="stylesheet">
+		<link rel="preconnect" href="https://fonts.googleapis.com" />
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+		<link
+			href="https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;600;700&family=Poppins:wght@400;500;600;700&display=swap"
+			rel="stylesheet"
+		/>
 
-		<script>try{document.documentElement.setAttribute('data-theme',localStorage.getItem('theme'));}catch(e){}</script>
+		<script>
+			try {
+				let currentTheme = localStorage.getItem("theme");
+				if (currentTheme === null) {
+					if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+						currentTheme = "black";
+					} else {
+						currentTheme = "light";
+					}
+				}
+				document.documentElement.setAttribute("data-theme", currentTheme);
+
+				localStorage.setItem("theme", currentTheme);
+			} catch (e) {}
+		</script>
 		%sveltekit.head%
 	</head>
 	<body>

--- a/docs/static/one-light.prism.css
+++ b/docs/static/one-light.prism.css
@@ -28,6 +28,26 @@
  * --syntax-cursor-line: hsla(230, 8%, 24%, 0.05);
  */
 
+/* Prefer color scheme: dark */
+@media (prefers-color-scheme: dark) {
+	pre[class*="language-"],
+	code[class*="language-"] {
+		color: hsl(219, 13.5%, 71%);
+		background: hsl(204.1 38.4% 10.6%);
+	}
+
+	code[class*="language-"]::selection,
+	code[class*="language-"] *::selection,
+	pre[class*="language-"] *::selection {
+		background: hsl(230 6% 32%);
+		color: inherit;
+	}
+
+	.token.punctuation {
+		color: hsl(219, 13.5%, 71%);
+	}
+}
+
 code[class*="language-"],
 pre[class*="language-"] {
 	background: hsl(230, 1%, 98%);
@@ -445,24 +465,4 @@ html[data-theme="black"] pre[class*="language-"] *::selection {
 /* Dark mode Code blocks */
 html[data-theme="black"] .token.punctuation {
 	color: hsl(219, 13.5%, 71%);
-}
-
-/* Prefer color scheme: dark */
-@media (prefers-color-scheme: dark) {
-	pre[class*="language-"],
-	code[class*="language-"] {
-		color: hsl(219, 13.5%, 71%);
-		background: hsl(204.1 38.4% 10.6%);
-	}
-
-	code[class*="language-"]::selection,
-	code[class*="language-"] *::selection,
-	pre[class*="language-"] *::selection {
-		background: hsl(230 6% 32%);
-		color: inherit;
-	}
-
-	.token.punctuation {
-		color: hsl(219, 13.5%, 71%);
-	}
 }

--- a/docs/static/one-light.prism.css
+++ b/docs/static/one-light.prism.css
@@ -426,3 +426,43 @@ pre > code.diff-highlight .token.token.inserted:not(.prefix) *::selection {
 .prism-previewer-easing.prism-previewer-easing circle {
 	fill: transparent;
 }
+
+/* Manual toggle Dark mode */
+html[data-theme="black"] pre[class*="language-"],
+html[data-theme="black"] code[class*="language-"] {
+	color: hsl(219, 13.5%, 71%);
+	background: hsl(204.1 38.4% 10.6%);
+}
+
+/* Dark mode Selection */
+html[data-theme="black"] code[class*="language-"]::selection,
+html[data-theme="black"] code[class*="language-"] *::selection,
+html[data-theme="black"] pre[class*="language-"] *::selection {
+	background: hsl(230 6% 32%);
+	color: inherit;
+}
+
+/* Dark mode Code blocks */
+html[data-theme="black"] .token.punctuation {
+	color: hsl(219, 13.5%, 71%);
+}
+
+/* Prefer color scheme: dark */
+@media (prefers-color-scheme: dark) {
+	pre[class*="language-"],
+	code[class*="language-"] {
+		color: hsl(219, 13.5%, 71%);
+		background: hsl(204.1 38.4% 10.6%);
+	}
+
+	code[class*="language-"]::selection,
+	code[class*="language-"] *::selection,
+	pre[class*="language-"] *::selection {
+		background: hsl(230 6% 32%);
+		color: inherit;
+	}
+
+	.token.punctuation {
+		color: hsl(219, 13.5%, 71%);
+	}
+}


### PR DESCRIPTION
# Description

Add a dark mode background to the code blocks when the user toggles dark mode or when their preferred color scheme is set to dark. Choose a background color that has the same tone as the suggested color.

## Issue Ticket Number

Fixes #53 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/svelte-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/svelte-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation

I'm participating in Hacktoberfest. 
