### PR TITLE
fix: Validation for cloud name

### DIFF
--- a/svelte-cloudinary/src/lib/cloudinary.ts
+++ b/svelte-cloudinary/src/lib/cloudinary.ts
@@ -26,3 +26,9 @@ export async function pollForProcessingImage(options: PollForProcessingImageOpti
   }
   return true;
 }
+
+export function checkCloudinaryCloudName(cloudName: string) {
+  if (!cloudName) {
+    throw new Error("A Cloudinary Cloud name is required, please make sure VITE_PUBLIC_CLOUDINARY_CLOUD_NAME is set and configured in your environment");
+  }
+}

--- a/svelte-cloudinary/src/lib/cloudinary.ts
+++ b/svelte-cloudinary/src/lib/cloudinary.ts
@@ -29,6 +29,6 @@ export async function pollForProcessingImage(options: PollForProcessingImageOpti
 
 export function checkCloudinaryCloudName(cloudName: string) {
   if (!cloudName) {
-    throw new Error("A Cloudinary Cloud name is required, please make sure VITE_PUBLIC_CLOUDINARY_CLOUD_NAME is set and configured in your environment");
+    throw new Error("[Svelte-cloudinary] A Cloudinary Cloud name is required, please make sure VITE_PUBLIC_CLOUDINARY_CLOUD_NAME is set and configured in your environment");
   }
 }

--- a/svelte-cloudinary/src/lib/components/CldUploadWidget.svelte
+++ b/svelte-cloudinary/src/lib/components/CldUploadWidget.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { triggerOnIdle, loadCloudinary } from '$lib/util.js';
+	import { checkCloudinaryCloudName } from '$lib/cloudinary.js';
 	import type {
 		ResultsEvents,
 		UploadWidget,
@@ -21,6 +22,9 @@
 	let widget: UploadWidget;
 	const signed = !!signatureEndpoint;
 	const WIDGET_WATCHED_EVENTS = ['success', 'display-changed'];
+
+	// Validation
+	checkCloudinaryCloudName(import.meta.env.VITE_PUBLIC_CLOUDINARY_CLOUD_NAME);
 
 	// State
 	let isLoading = true;

--- a/svelte-cloudinary/src/lib/components/CldVideoPlayer.svelte
+++ b/svelte-cloudinary/src/lib/components/CldVideoPlayer.svelte
@@ -43,6 +43,7 @@
 <script lang="ts">
 	import { parseUrl } from '@cloudinary-util/util';
 	import { loadCloudinary } from '$lib/util.js';
+	import { checkCloudinaryCloudName } from '$lib/cloudinary.js';
 	import { onMount } from 'svelte';
 
 	const idRef = Math.ceil(Math.random() * 100000);
@@ -144,6 +145,9 @@
 				};
 			}
 
+			// Validation
+			checkCloudinaryCloudName(import.meta.env.VITE_PUBLIC_CLOUDINARY_CLOUD_NAME);
+			
 			let playerOptions: CloudinaryVideoPlayerOptions = {
 				autoplayMode: autoPlay,
 				cloud_name: import.meta.env.VITE_PUBLIC_CLOUDINARY_CLOUD_NAME,

--- a/svelte-cloudinary/src/lib/helpers/getCldImageUrl.ts
+++ b/svelte-cloudinary/src/lib/helpers/getCldImageUrl.ts
@@ -1,4 +1,5 @@
 import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
+import { checkCloudinaryCloudName } from '../cloudinary.ts';
 import type { ImageOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-util/url-loader';
 
 import {
@@ -30,6 +31,10 @@ export function getCldImageUrl(
   config?: ConfigOptions,
   analytics?: AnalyticsOptions
 ) {
+
+  // Validation
+  checkCloudinaryCloudName(import.meta.env.VITE_PUBLIC_CLOUDINARY_CLOUD_NAME);
+
   return constructCloudinaryUrl({
     options,
     config: Object.assign(

--- a/svelte-cloudinary/src/lib/helpers/getCldImageUrl.ts
+++ b/svelte-cloudinary/src/lib/helpers/getCldImageUrl.ts
@@ -1,5 +1,5 @@
 import { constructCloudinaryUrl } from '@cloudinary-util/url-loader';
-import { checkCloudinaryCloudName } from '../cloudinary.ts';
+import { checkCloudinaryCloudName } from '../cloudinary.js';
 import type { ImageOptions, ConfigOptions, AnalyticsOptions } from '@cloudinary-util/url-loader';
 
 import {


### PR DESCRIPTION
# Description
Closes #58 

- Add validation for the environment variable ```VITE_PUBLIC_CLOUDINARY_CLOUD_NAME```

## Changes made
- Added a custom function ```checkCloudinaryCloudName``` in the ```cloudinary.ts```,  which accepts the cloud name as a parameter and throws error if it is null
- Imported that function in the below files and passed environment variable as a parameter:
  - **CldVideoPlayer.svelte** (svelte-cloudinary/src/lib/components/CldVideoPlayer.svelte)
  - **CldUploadWidget.svelte** (svelte-cloudinary/src/lib/components/CldUploadWidget.svelte)

- **Note** : When i run ```pnpm install``` it gives me error, so i am not able to test it locally
<!-- Include a summary of the change made and also list the dependencies that are required if any -->

<br>

## Issue Ticket Number

Fixes #58 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/svelte-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [ ] I have created an [issue](https://github.com/cloudinary-community/svelte-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/svelte-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [ ] I have run tests locally to ensure they all pass
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes needed to the documentation
