### PR TITLE
docs: Changed 'next-cloudinary' to 'svelte-cloudinary'.

### DIFF
--- a/docs/src/docs/components/cldvideoplayer/usage.md
+++ b/docs/src/docs/components/cldvideoplayer/usage.md
@@ -18,7 +18,7 @@ The CldVideoPlayer component helps to embed Cloudinary videos using the [Cloudin
 The basic required props include `width`, `height`, and `src`:
 
 ```jsx
-import { CldVideoPlayer } from 'next-cloudinary';
+import { CldVideoPlayer } from 'svelte-cloudinary';
 
 <CldVideoPlayer
   width="1920"

--- a/docs/src/docs/helpers/getcldimageurl/usage.md
+++ b/docs/src/docs/helpers/getcldimageurl/usage.md
@@ -17,7 +17,7 @@ You can use the getCldImageUrl helper function to generate Cloudinary URLs witho
 The basic required options include `width`, `height`, and `src`:
 
 ```js
-import { getCldImageUrl } from 'next-cloudinary';
+import { getCldImageUrl } from 'svelte-cloudinary';
 
 const url = getCldImageUrl({
   width: 960,


### PR DESCRIPTION
# Description
 Was reading the docs and noticed there were some places where 'next-cloudinary' was used. Fixed them to `svelte-cloudinary`.

## Type of change

- [x] Fix or improve the documentation

# Checklist

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.m
- [x] I have made corresponding changes needed to the documentation
