### PR TITLE
Fixes CldVideoPlayer not able to use PUBLIC_ env var

### DIFF
--- a/svelte-cloudinary/src/lib/components/CldVideoPlayer.svelte
+++ b/svelte-cloudinary/src/lib/components/CldVideoPlayer.svelte
@@ -45,6 +45,7 @@
 	import { loadCloudinary } from '$lib/util.js';
 	import { checkCloudinaryCloudName } from '$lib/cloudinary.js';
 	import { onMount } from 'svelte';
+	import { env } from '$env/dynamic/public';
 
 	const idRef = Math.ceil(Math.random() * 100000);
 	type $$Props = CldVideoPlayerProps;
@@ -146,11 +147,13 @@
 			}
 
 			// Validation
-			checkCloudinaryCloudName(import.meta.env.VITE_PUBLIC_CLOUDINARY_CLOUD_NAME);
+			const cloudName = env.PUBLIC_CLOUDINARY_CLOUD_NAME || import.meta.env.VITE_PUBLIC_CLOUDINARY_CLOUD_NAME;
+
+			checkCloudinaryCloudName(cloudName);
 			
 			let playerOptions: CloudinaryVideoPlayerOptions = {
 				autoplayMode: autoPlay,
-				cloud_name: import.meta.env.VITE_PUBLIC_CLOUDINARY_CLOUD_NAME,
+				cloud_name: cloudName,
 				controls,
 				fontFace: fontFace || '',
 				loop,


### PR DESCRIPTION
# Description

PUBLIC_ was never exposed for CldVideoPlayer when the changes were previously made in: https://github.com/cloudinary-community/svelte-cloudinary/pull/82

## Issue Ticket Number

Fixes #89 