### PR TITLE
Added docs for the fillBackground seed prop

### DIFF
--- a/packages/docs/src/content/docs/components/image/configuration.mdx
+++ b/packages/docs/src/content/docs/components/image/configuration.mdx
@@ -495,6 +495,11 @@ a background, or an object, which can take the following options:
 			type: 'string',
 			example: () => <code>cupcakes</code>,
 		},
+		{
+			prop: 'seed',
+			type: 'number',
+			example: () => (<code>3</code>),
+		},
 	]}
 />
 
@@ -512,7 +517,8 @@ Customizing options:
 fillBackground={{
   crop: 'clpad',
   gravity: 'south',
-  prompt: 'cupcakes'
+  prompt: 'cupcakes',
+  seed: '3'
 }}
 ```
 

--- a/packages/docs/src/content/docs/helpers/getcldimageurl/configuration.mdx
+++ b/packages/docs/src/content/docs/helpers/getcldimageurl/configuration.mdx
@@ -466,6 +466,11 @@ a background, or an object, which can take the following options:
 			type: 'string',
 			example: () => <code>cupcakes</code>,
 		},
+		{
+			prop: 'seed',
+			type: 'number',
+			example: () => (<code>3</code>),
+		},
 	]}
 />
 
@@ -483,7 +488,8 @@ Customizing options:
 fillBackground: {
   crop: 'clpad',
   gravity: 'south',
-  prompt: 'cupcakes'
+  prompt: 'cupcakes',
+  seed: '3'
 }
 ```
 


### PR DESCRIPTION
# Description

The new `fillBackground.seed` prop has been added to the docs, based on the [next-cloudinary change](https://github.com/cloudinary-community/next-cloudinary/commit/18b0dbdc38c5c76dd908c170ce5f30c8d1d96a12#diff-f3fcbfe8088ead10a15972f85b001f9c2e0e51b14522a76b4c3cc7da68ecb653)

The changes were made to the `fillBackground` table in the following files, as well as the examples you can find under those tables :-

 - `packages/docs/src/content/docs/components/image/configuration.mdx`
 - `packages/docs/src/content/docs/helpers/getcldimageurl/configuration.mdx`

<!-- Include a summary of the change made and also list the dependencies that are required if any -->

## Issue Ticket Number

Fixes #186 

<!-- Specify above which issue this fixes by referencing the issue number (`#<ISSUE_NUMBER>`) or issue URL. -->
<!-- Example: Fixes https://github.com/cloudinary-community/svelte-cloudinary/issues/<ISSUE_NUMBER> -->

## Type of change

<!-- Please select all options that are applicable. -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Fix or improve the documentation
- [ ] This change requires a documentation update


# Checklist

<!-- These must all be followed and checked. -->

- [x] I have followed the contributing guidelines of this project as mentioned in [CONTRIBUTING.md](/CONTRIBUTING.md)
- [x] I have created an [issue](https://github.com/cloudinary-community/svelte-cloudinary/issues) ticket for this PR
- [x] I have checked to ensure there aren't other open [Pull Requests](https://github.com/cloudinary-community/svelte-cloudinary/pulls) for the same update/change?
- [x] I have performed a self-review of my own code
- [x] I have run tests locally to ensure they all pass
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes needed to the documentation
