### PR TITLE
docs: remove broken stray title from home page

### DIFF
--- a/packages/docs/src/content/docs/index.mdx
+++ b/packages/docs/src/content/docs/index.mdx
@@ -35,5 +35,3 @@ import { CardGrid, Card } from '@astrojs/starlight/components';
 		...
 	</Card>
 </CardGrid>
-
-<center>### Transform & Deliver at Scale with Cloudinary</center>


### PR DESCRIPTION
Removed unformatted text from the homepage documentation file
(packages/docs/src/content/docs/index.mdx) as mentioned in issue #190.